### PR TITLE
refactor(ot-46): move all secrets that has been hardcoded to .env

### DIFF
--- a/api-gateway/src/app.module.ts
+++ b/api-gateway/src/app.module.ts
@@ -2,12 +2,19 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthController } from './auth/auth.controller';
-import { AuthService } from './auth/auth.service';
 import { AuthModule } from './auth/auth.module';
+import { ConfigModule } from '@nestjs/config';
+import { join } from 'path';
 
 @Module({
-  imports: [AuthModule],
-  controllers: [AppController,AuthController],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      envFilePath: join(__dirname, '..', '..', '.env'),
+    }),
+    AuthModule
+  ],
+  controllers: [AppController, AuthController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule { }

--- a/api-gateway/src/auth/auth.module.ts
+++ b/api-gateway/src/auth/auth.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { ClientsModule } from '@nestjs/microservices';
-import { grpcClientOptions } from 'src/auth.grpc-client';
+import { grpcClientOptions } from 'src/client-options/auth.grpc-client';
 
 @Module({
   imports: [

--- a/api-gateway/src/client-options/auth.grpc-client.ts
+++ b/api-gateway/src/client-options/auth.grpc-client.ts
@@ -1,4 +1,3 @@
-
 import { ClientProviderOptions, Transport } from '@nestjs/microservices';
 import { join } from 'path';
 
@@ -7,7 +6,7 @@ export const grpcClientOptions: ClientProviderOptions = {
   transport: Transport.GRPC,
   options: {
     package: 'auth',
-    protoPath: join(__dirname, './proto/auth.proto'),
+    protoPath: join(__dirname, '../proto/auth.proto'),
     url: 'localhost:50051',
   },
 };

--- a/api-gateway/src/main.ts
+++ b/api-gateway/src/main.ts
@@ -1,8 +1,14 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+
+  app.enableCors();
+
+  const configService = app.get(ConfigService);
+  const port = configService.get<number>('SERVER_PORT') || 3000;
+  await app.listen(port);
 }
 bootstrap();

--- a/auth-service/src/app.module.ts
+++ b/auth-service/src/app.module.ts
@@ -7,27 +7,33 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './auth/entities/user.entity';
 import { MailerService } from './mailer/mailer.service';
 import { MailerModule } from './mailer/mailer.module';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { join } from 'path';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
-      isGlobal: true, 
+      isGlobal: true,
+      envFilePath: join(__dirname, '..', '..', '.env'),
     }),
-    TypeOrmModule.forRoot({
-      type: 'mysql',
-      host: '192.168.130.129',
-      port: 3306,
-      username: 'octaltask',
-      password: 'octaltask',
-      database: 'octaltask',
-      entities: [User],
-      synchronize: true, 
+    TypeOrmModule.forRootAsync({
+      useFactory: async (config: ConfigService) => ({
+        type: config.get<'mysql' | 'postgres' | 'sqlite'>('DB_TYPE') as any,
+        host: config.get<string>('DB_HOST'),
+        port: config.get<number>('DB_PORT'),
+        username: config.get<string>('DB_USERNAME'),
+        password: config.get<string>('DB_PASSWORD'),
+        database: config.get<string>('DB_DATABASE'),
+        entities: [User],
+        synchronize: true,
+        logging: true,
+      }),
+      inject: [ConfigService],
     }),
     AuthModule,
     MailerModule],
   controllers: [AppController, AuthController],
   providers: [AppService, MailerService],
-  
+
 })
-export class AppModule {}
+export class AppModule { }

--- a/auth-service/src/auth/auth.module.ts
+++ b/auth-service/src/auth/auth.module.ts
@@ -21,7 +21,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
         secret: configService.get<string>('JWT_SECRET'),
-        signOptions: { expiresIn: '1d' },
+        signOptions: { expiresIn: configService.get<string>('TOKEN_EXPIRE_TIME') },
       }),
     }),
 

--- a/auth-service/src/mailer/mailer.module.ts
+++ b/auth-service/src/mailer/mailer.module.ts
@@ -4,33 +4,37 @@ import { MailerModule as NestMailerModule } from '@nestjs-modules/mailer';
 import { MailerService } from './mailer.service';
 import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
 import { join } from 'path';
+import { ConfigService } from '@nestjs/config';
 
 @Module({
   imports: [
-    NestMailerModule.forRoot({
-      transport: {
-        host: 'smtp.gmail.com',
-        port: 587,
-        secure: false, // true nếu dùng port 465
-        auth: {
-          user: 'octaltask.service@gmail.com',
-          pass: 'svnm tpwh ttfw lfnh', // dùng App Password nếu dùng Gmail
+    NestMailerModule.forRootAsync({
+      useFactory: async (config: ConfigService) => ({
+        transport: {
+          host: config.get('MAIL_HOST'),
+          port: config.get('MAIL_PORT'),
+          secure: false,
+          auth: {
+            user: config.get('MAIL_USER'),
+            pass: config.get('MAIL_PASSWORD'),
+          },
         },
-      },
-      defaults: {
-        from: '"OctalTask" <octaltask.service@gmail.com>',
-      },
-      template: {
-        dir: join(__dirname, '../mailer/templates'),
-        adapter: new HandlebarsAdapter(),
-        options: {
-          strict: true,
+        defaults: {
+          from: `"OctalTask Service" <${config.get('MAIL_FROM')}>`,
         },
-      },
+        template: {
+          dir: join(__dirname, '../mailer/templates'),
+          adapter: new HandlebarsAdapter(),
+          options: {
+            strict: true,
+          },
+        },
+      }),
+      inject: [ConfigService],
     }),
   ],
   controllers: [],
   providers: [MailerService],
-  exports: [MailerService], // 👈 export để chỗ khác dùng được
+  exports: [MailerService], // export để chỗ khác dùng được
 })
-export class MailerModule {}
+export class MailerModule { }

--- a/task-service/src/app.module.ts
+++ b/task-service/src/app.module.ts
@@ -5,22 +5,28 @@ import { TaskModule } from './task/task.module';
 import { Task } from './task/entities/task.entity';
 import { User } from './task/entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { join } from 'path';
 
 @Module({
   imports: [
-    TypeOrmModule.forRoot({
-      type: 'mysql',
-      host: '127.0.0.1',
-      port: 3306,
-      username: 'octaltask',
-      password: 'octaltask',
-      database: 'octaltask',
-      entities: [Task, User],
-      synchronize: true,
-    }),
     ConfigModule.forRoot({
       isGlobal: true,
+      envFilePath: join(__dirname, '..', '..', '.env'),
+    }),
+    TypeOrmModule.forRootAsync({
+      useFactory: async (config: ConfigService) => ({
+        type: config.get<'mysql' | 'postgres' | 'sqlite'>('DB_TYPE') as any,
+        host: config.get<string>('DB_HOST'),
+        port: config.get<number>('DB_PORT'),
+        username: config.get<string>('DB_USERNAME'),
+        password: config.get<string>('DB_PASSWORD'),
+        database: config.get<string>('DB_DATABASE'),
+        entities: [Task, User],
+        synchronize: true,
+        logging: true,
+      }),
+      inject: [ConfigService],
     }),
     TaskModule,
   ],


### PR DESCRIPTION
## Things have been done:
- Change all the secret's values.
- Move all secrets to `.env` file instead of hardcoding.
- Use only one `.env` in the root folder (`octaltask-api`) instead of 6 `.env` files in 6 microservices.
- Make use of `ConfigService`.

**Purpose:** use only one `.env` file for easy deployment using Docker Swarm or Kubernetes.

## Notes for other developers:
- The `.env` mustn't be in the `auth-service`, `task-service`, `user-service`,... folder. It **must** be in `octaltask-api` (root folder) now.
- Every secret you guy add to the project. It **must** be in the `.env` file from now on.