### PR TITLE
Ot-54: Implement full comment CRUD for tasks

### DIFF
--- a/api-gateway/src/entities/comment.entity.ts
+++ b/api-gateway/src/entities/comment.entity.ts
@@ -1,0 +1,22 @@
+// src/task/entities/comment.entity.ts
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import { User } from './user.entity';
+import { Task } from './task.entity';
+
+@Entity('comments')
+export class Comment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  content: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => Task, (task) => task.comments, { onDelete: 'CASCADE' })
+  task: Task;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+}

--- a/api-gateway/src/entities/task.entity.ts
+++ b/api-gateway/src/entities/task.entity.ts
@@ -1,25 +1,30 @@
 // src/task/entities/task.entity.ts
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm'
-import { User } from './user.entity'
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from 'typeorm';
+import { User } from './user.entity';
+import { Comment } from './comment.entity';
 
 @Entity('tasks')
 export class Task {
   @PrimaryGeneratedColumn()
-  id: number
+  id: number;
 
   @Column()
-  title: string
+  title: string;
 
   @Column({ nullable: true })
-  description?: string
+  description?: string;
 
   @Column({ default: false })
-  isCompleted: boolean
+  isCompleted: boolean;
 
   @Column({ type: 'timestamp', nullable: true })
-  dueDate?: Date
+  dueDate?: Date;
 
   @ManyToOne(() => User, (user) => user.tasks, { onDelete: 'CASCADE' })
-  user: User
-  createdBy: any
+  user: User;
+  
+  @OneToMany(() => Comment, (comment) => comment.task)
+  comments: Comment[];
+  
+  createdBy: any;
 }

--- a/api-gateway/src/proto/task.proto
+++ b/api-gateway/src/proto/task.proto
@@ -13,6 +13,11 @@ service TaskService {
   rpc AdminUpdateTask (AdminUpdateTaskRequest) returns (TaskResponse);
   rpc AdminDeleteTask (TaskIdRequest) returns (MessageResponse);
   rpc GetAllTasksByUserId (UserIdRequest) returns (TaskListResponse);
+  
+  // New comment-related methods
+  rpc AddCommentToTask (AddCommentRequest) returns (CommentResponse);
+  rpc GetCommentsForTask (TaskCommentsRequest) returns (CommentListResponse);
+  rpc UpdateComment (UpdateCommentRequest) returns (CommentResponse);
 }
 
 message EmptyRequest {}
@@ -80,4 +85,34 @@ message TaskListResponse {
 
 message MessageResponse {
   string message = 1;
+}
+
+// New message types for comment functionality
+message AddCommentRequest {
+  int32 taskId = 1;
+  string content = 2;
+  UserInfo user = 3;
+}
+
+message TaskCommentsRequest {
+  int32 taskId = 1;
+  UserInfo user = 2;
+}
+
+message CommentResponse {
+  int32 id = 1;
+  string content = 2;
+  string createdAt = 3;
+  UserInfo user = 4;
+}
+
+message CommentListResponse {
+  repeated CommentResponse comments = 1;
+}
+
+message UpdateCommentRequest {
+  int32 taskId = 1;
+  int32 commentId = 2;
+  string content = 3;
+  UserInfo user = 4;
 }

--- a/api-gateway/src/proto/task.proto
+++ b/api-gateway/src/proto/task.proto
@@ -18,6 +18,7 @@ service TaskService {
   rpc AddCommentToTask (AddCommentRequest) returns (CommentResponse);
   rpc GetCommentsForTask (TaskCommentsRequest) returns (CommentListResponse);
   rpc UpdateComment (UpdateCommentRequest) returns (CommentResponse);
+  rpc DeleteComment (DeleteCommentRequest) returns (MessageResponse);
 }
 
 message EmptyRequest {}
@@ -115,4 +116,10 @@ message UpdateCommentRequest {
   int32 commentId = 2;
   string content = 3;
   UserInfo user = 4;
+}
+
+message DeleteCommentRequest{
+  int32 taskId = 1;
+  int32 commentId = 2;
+  UserInfo user = 3;
 }

--- a/api-gateway/src/task/dto/comment-response.dto.ts
+++ b/api-gateway/src/task/dto/comment-response.dto.ts
@@ -1,0 +1,35 @@
+// src/task/dto/comment-response.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserInfoDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ example: 'John Doe' })
+  name: string;
+
+  @ApiProperty({ example: 'user' })
+  role: string;
+}
+
+export class CommentResponseDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'This task is progressing well!' })
+  content: string;
+
+  @ApiProperty({ example: '2025-05-16T10:30:00Z' })
+  createdAt: string;
+
+  @ApiProperty()
+  user: UserInfoDto;
+}
+
+export class CommentListResponseDto {
+  @ApiProperty({ type: [CommentResponseDto] })
+  comments: CommentResponseDto[];
+}

--- a/api-gateway/src/task/dto/create-comment.dto.ts
+++ b/api-gateway/src/task/dto/create-comment.dto.ts
@@ -1,0 +1,15 @@
+// src/task/dto/create-comment.dto.ts
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateCommentDto {
+  @ApiProperty({
+    description: 'Content of the comment',
+    example: 'This task is progressing well!',
+    required: true
+  })
+  @IsNotEmpty()
+  @IsString()
+  @MinLength(1)
+  content: string;
+}

--- a/api-gateway/src/task/dto/update-comment.dto.ts
+++ b/api-gateway/src/task/dto/update-comment.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class UpdateCommentDto {
+  @ApiProperty({
+    description: 'Updated content of the comment',
+    example: 'This is the updated comment text'
+  })
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+}

--- a/api-gateway/src/task/task.controller.ts
+++ b/api-gateway/src/task/task.controller.ts
@@ -30,6 +30,9 @@ import {
   ApiCreatedResponse,
   ApiOkResponse
 } from '@nestjs/swagger';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { CommentListResponseDto, CommentResponseDto } from './dto/comment-response.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
 
 @ApiTags('Task')
 @ApiBearerAuth('accessToken')
@@ -376,5 +379,86 @@ export class TaskController {
   @ApiForbiddenResponse({ description: 'Forbidden - Admin access required' })
   async getAllTasksByUserId(@Param('userId') userId: string) {
     return this.taskService.getAllTasksByUserId(parseInt(userId, 10));
+  }
+
+  @Post(':id/comments')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Add a comment to a task' })
+  @ApiParam({ name: 'id', description: 'Task ID', type: 'number' })
+  @ApiBody({ type: CreateCommentDto })
+  @ApiCreatedResponse({ 
+    description: 'Comment added successfully',
+    type: CommentResponseDto
+  })
+  @ApiNotFoundResponse({ description: 'Task not found' })
+  @ApiForbiddenResponse({ description: 'Permission denied to comment on this task' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  async addCommentToTask(
+    @Param('id') id: string,
+    @Body(ValidationPipe) createCommentDto: CreateCommentDto,
+    @Request() req
+  ) {
+    return this.taskService.addCommentToTask(parseInt(id, 10), createCommentDto, req.user);
+  }
+
+  @Get(':id/comments')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get all comments for a task' })
+  @ApiParam({ name: 'id', description: 'Task ID', type: 'number' })
+  @ApiOkResponse({ 
+    description: 'Retrieved all comments for the task',
+    type: CommentListResponseDto
+  })
+  @ApiNotFoundResponse({ description: 'Task not found' })
+  @ApiForbiddenResponse({ description: 'Permission denied to view comments on this task' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  async getCommentsForTask(@Param('id') id: string, @Request() req) {
+    return this.taskService.getCommentsForTask(parseInt(id, 10), req.user);
+  }
+
+  @Patch(':taskId/comments/:commentId')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update a comment on a task' })
+  @ApiParam({ name: 'taskId', description: 'Task ID', type: 'number' })
+  @ApiParam({ name: 'commentId', description: 'Comment ID', type: 'number' })
+  @ApiBody({ type: UpdateCommentDto })
+  @ApiOkResponse({ 
+    description: 'Comment updated successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 1 },
+        content: { type: 'string', example: 'This is the updated comment text' },
+        createdAt: { type: 'string', example: '2025-05-17T10:30:00Z' },
+        user: {
+          type: 'object',
+          properties: {
+            userId: { type: 'number', example: 1 },
+            email: { type: 'string', example: 'user@example.com' },
+            name: { type: 'string', example: 'John Doe' },
+            role: { type: 'string', example: 'user' }
+          }
+        }
+      }
+    }
+  })
+  @ApiNotFoundResponse({ description: 'Task or comment not found' })
+  @ApiForbiddenResponse({ description: 'Permission denied to update this comment' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  async updateComment(
+    @Param('taskId') taskId: string,
+    @Param('commentId') commentId: string,
+    @Body(ValidationPipe) updateCommentDto: UpdateCommentDto,
+    @Request() req
+  ) {
+    return this.taskService.updateComment(
+      parseInt(taskId, 10), 
+      parseInt(commentId, 10), 
+      updateCommentDto, 
+      req.user
+    );
   }
 }

--- a/api-gateway/src/task/task.controller.ts
+++ b/api-gateway/src/task/task.controller.ts
@@ -38,13 +38,13 @@ import { UpdateCommentDto } from './dto/update-comment.dto';
 @ApiBearerAuth('accessToken')
 @Controller('tasks')
 export class TaskController {
-  constructor(private readonly taskService: TaskService) {}
+  constructor(private readonly taskService: TaskService) { }
 
   @Post()
   @UseGuards(JwtGuard)
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Create a new task' })
-  @ApiCreatedResponse({ 
+  @ApiCreatedResponse({
     description: 'The task has been successfully created',
     schema: {
       type: 'object',
@@ -76,7 +76,7 @@ export class TaskController {
   @UseGuards(JwtGuard)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Get all tasks for the current user' })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Retrieved all tasks for the current user',
     schema: {
       type: 'object',
@@ -116,7 +116,7 @@ export class TaskController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Get a task by ID' })
   @ApiParam({ name: 'id', description: 'Task ID', type: 'number' })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Retrieved the task successfully',
     schema: {
       type: 'object',
@@ -151,7 +151,7 @@ export class TaskController {
   @ApiOperation({ summary: 'Update a task' })
   @ApiParam({ name: 'id', description: 'Task ID', type: 'number' })
   @ApiBody({ type: UpdateTaskDto })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Task updated successfully',
     schema: {
       type: 'object',
@@ -177,8 +177,8 @@ export class TaskController {
   @ApiForbiddenResponse({ description: 'Permission denied' })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   async update(
-    @Param('id') id: string, 
-    @Body(ValidationPipe) updateTaskDto: UpdateTaskDto, 
+    @Param('id') id: string,
+    @Body(ValidationPipe) updateTaskDto: UpdateTaskDto,
     @Request() req
   ) {
     return this.taskService.update(parseInt(id, 10), updateTaskDto, req.user);
@@ -189,7 +189,7 @@ export class TaskController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Delete a task' })
   @ApiParam({ name: 'id', description: 'Task ID', type: 'number' })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Task deleted successfully',
     schema: {
       type: 'object',
@@ -210,7 +210,7 @@ export class TaskController {
   @UseGuards(JwtGuard, AdminGuard)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Admin: Get all tasks in the system' })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Retrieved all tasks successfully',
     schema: {
       type: 'object',
@@ -251,7 +251,7 @@ export class TaskController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Admin: Get a task by ID' })
   @ApiParam({ name: 'id', description: 'Task ID', type: 'number' })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Retrieved the task successfully',
     schema: {
       type: 'object',
@@ -286,7 +286,7 @@ export class TaskController {
   @ApiOperation({ summary: 'Admin: Update any task' })
   @ApiParam({ name: 'id', description: 'Task ID', type: 'number' })
   @ApiBody({ type: UpdateTaskDto })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Task updated successfully',
     schema: {
       type: 'object',
@@ -312,7 +312,7 @@ export class TaskController {
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   @ApiForbiddenResponse({ description: 'Forbidden - Admin access required' })
   async adminUpdateTask(
-    @Param('id') id: string, 
+    @Param('id') id: string,
     @Body(ValidationPipe) updateTaskDto: UpdateTaskDto
   ) {
     return this.taskService.adminUpdateTask(parseInt(id, 10), updateTaskDto);
@@ -323,7 +323,7 @@ export class TaskController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Admin: Delete any task' })
   @ApiParam({ name: 'id', description: 'Task ID', type: 'number' })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Task deleted successfully',
     schema: {
       type: 'object',
@@ -344,7 +344,7 @@ export class TaskController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Admin: Get all tasks by user ID' })
   @ApiParam({ name: 'userId', description: 'User ID', type: 'number' })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Retrieved all tasks for the specified user',
     schema: {
       type: 'object',
@@ -387,7 +387,7 @@ export class TaskController {
   @ApiOperation({ summary: 'Add a comment to a task' })
   @ApiParam({ name: 'id', description: 'Task ID', type: 'number' })
   @ApiBody({ type: CreateCommentDto })
-  @ApiCreatedResponse({ 
+  @ApiCreatedResponse({
     description: 'Comment added successfully',
     type: CommentResponseDto
   })
@@ -407,7 +407,7 @@ export class TaskController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Get all comments for a task' })
   @ApiParam({ name: 'id', description: 'Task ID', type: 'number' })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Retrieved all comments for the task',
     type: CommentListResponseDto
   })
@@ -425,7 +425,7 @@ export class TaskController {
   @ApiParam({ name: 'taskId', description: 'Task ID', type: 'number' })
   @ApiParam({ name: 'commentId', description: 'Comment ID', type: 'number' })
   @ApiBody({ type: UpdateCommentDto })
-  @ApiOkResponse({ 
+  @ApiOkResponse({
     description: 'Comment updated successfully',
     schema: {
       type: 'object',
@@ -455,9 +455,39 @@ export class TaskController {
     @Request() req
   ) {
     return this.taskService.updateComment(
-      parseInt(taskId, 10), 
-      parseInt(commentId, 10), 
-      updateCommentDto, 
+      parseInt(taskId, 10),
+      parseInt(commentId, 10),
+      updateCommentDto,
+      req.user
+    );
+  }
+
+  @Delete(':taskId/comments/:commentId')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Delete a comment on a task' })
+  @ApiParam({ name: 'taskId', description: 'Task ID', type: 'number' })
+  @ApiParam({ name: 'commentId', description: 'Comment ID', type: 'number' })
+  @ApiOkResponse({
+    description: 'Comment deleted successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string', example: 'Comment deleted successfully' }
+      }
+    }
+  })
+  @ApiNotFoundResponse({ description: 'Task or comment not found' })
+  @ApiForbiddenResponse({ description: 'Permission denied to delete this comment' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  async deleteComment(
+    @Param('taskId') taskId: string,
+    @Param('commentId') commentId: string,
+    @Request() req
+  ) {
+    return this.taskService.deleteComment(
+      parseInt(taskId, 10),
+      parseInt(commentId, 10),
       req.user
     );
   }

--- a/api-gateway/src/task/task.service.ts
+++ b/api-gateway/src/task/task.service.ts
@@ -20,6 +20,7 @@ interface TaskGrpcService {
   addCommentToTask(data: any): any;
   getCommentsForTask(data: any): any;
   updateComment(data: any):any;
+  deleteComment(data: any):any;
 }
 
 @Injectable()
@@ -378,5 +379,23 @@ export class TaskService implements OnModuleInit {
       throw new HttpException('Task service unavailable', HttpStatus.SERVICE_UNAVAILABLE);
     }
   }
+
+  async deleteComment(taskId: number, commentId: number, user: any) {
+  const userData = {
+    userId: user.userId,
+    email: user.email,
+    role: user.role
+  };
+
+  const response = await firstValueFrom(
+    this.taskGrpcService.deleteComment({ taskId, commentId, user: userData }).pipe(
+      catchError(error => {
+        throw new HttpException(error.details || 'Failed to delete comment', HttpStatus.INTERNAL_SERVER_ERROR);
+      })
+    )
+  );
+  return response;
+}
+
   
 }

--- a/api-gateway/src/task/task.service.ts
+++ b/api-gateway/src/task/task.service.ts
@@ -3,6 +3,8 @@ import { ClientGrpc } from '@nestjs/microservices';
 import { catchError, firstValueFrom } from 'rxjs';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { UpdateTaskDto } from './dto/update-task.dto';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
 
 interface TaskGrpcService {
   createTask(data: any): any;
@@ -15,6 +17,9 @@ interface TaskGrpcService {
   adminUpdateTask(data: any): any;
   adminDeleteTask(data: any): any;
   getAllTasksByUserId(data: any): any;
+  addCommentToTask(data: any): any;
+  getCommentsForTask(data: any): any;
+  updateComment(data: any):any;
 }
 
 @Injectable()
@@ -269,4 +274,109 @@ export class TaskService implements OnModuleInit {
       throw new HttpException('Task service unavailable', HttpStatus.SERVICE_UNAVAILABLE);
     }
   }
+  async addCommentToTask(taskId: number, dto: CreateCommentDto, user: any) {
+    try {
+      const userData = {
+        userId: user.userId,
+        email: user.email,
+        role: user.role
+      };
+
+      const response = await firstValueFrom(
+        this.taskGrpcService.addCommentToTask({ 
+          taskId,
+          content: dto.content,
+          user: userData 
+        }).pipe(
+          catchError(error => {
+            if (error.details === 'Task not found') {
+              throw new HttpException('Task not found', HttpStatus.NOT_FOUND);
+            }
+            if (error.details === 'Permission denied to comment on this task') {
+              throw new HttpException('Permission denied', HttpStatus.FORBIDDEN);
+            }
+            throw new HttpException(error.details || 'Failed to add comment', HttpStatus.INTERNAL_SERVER_ERROR);
+          }),
+        ),
+      );
+      return response;
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException('Task service unavailable', HttpStatus.SERVICE_UNAVAILABLE);
+    }
+  }
+
+  async getCommentsForTask(taskId: number, user: any) {
+    try {
+      const userData = {
+        userId: user.userId,
+        email: user.email,
+        role: user.role
+      };
+
+      const response = await firstValueFrom(
+        this.taskGrpcService.getCommentsForTask({ 
+          taskId,
+          user: userData 
+        }).pipe(
+          catchError(error => {
+            if (error.details === 'Task not found') {
+              throw new HttpException('Task not found', HttpStatus.NOT_FOUND);
+            }
+            if (error.details === 'Permission denied to view comments on this task') {
+              throw new HttpException('Permission denied', HttpStatus.FORBIDDEN);
+            }
+            throw new HttpException(error.details || 'Failed to retrieve comments', HttpStatus.INTERNAL_SERVER_ERROR);
+          }),
+        ),
+      );
+      return response;
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException('Task service unavailable', HttpStatus.SERVICE_UNAVAILABLE);
+    }
+  }
+
+  async updateComment(taskId: number, commentId: number, dto: UpdateCommentDto, user: any) {
+    try {
+      const userData = {
+        userId: user.userId,
+        email: user.email,
+        role: user.role
+      };
+
+      const response = await firstValueFrom(
+        this.taskGrpcService.updateComment({ 
+          taskId,
+          commentId,
+          content: dto.content,
+          user: userData 
+        }).pipe(
+          catchError(error => {
+            if (error.details === 'Task not found') {
+              throw new HttpException('Task not found', HttpStatus.NOT_FOUND);
+            }
+            if (error.details === 'Comment not found') {
+              throw new HttpException('Comment not found', HttpStatus.NOT_FOUND);
+            }
+            if (error.details === 'Permission denied to update this comment') {
+              throw new HttpException('Permission denied', HttpStatus.FORBIDDEN);
+            }
+            throw new HttpException(error.details || 'Failed to update comment', HttpStatus.INTERNAL_SERVER_ERROR);
+          }),
+        ),
+      );
+      return response;
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException('Task service unavailable', HttpStatus.SERVICE_UNAVAILABLE);
+    }
+  }
+  
 }

--- a/task-service/src/app.module.ts
+++ b/task-service/src/app.module.ts
@@ -7,6 +7,7 @@ import { User } from './task/entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { join } from 'path';
+import { Comment } from './task/entities/comment.entity';
 
 @Module({
   imports: [
@@ -22,7 +23,7 @@ import { join } from 'path';
         username: config.get<string>('DB_USERNAME'),
         password: config.get<string>('DB_PASSWORD'),
         database: config.get<string>('DB_DATABASE'),
-        entities: [Task, User],
+        entities: [Task, User,Comment],
         synchronize: true,
         logging: true,
       }),

--- a/task-service/src/proto/task.proto
+++ b/task-service/src/proto/task.proto
@@ -13,6 +13,11 @@ service TaskService {
   rpc AdminUpdateTask (AdminUpdateTaskRequest) returns (TaskResponse);
   rpc AdminDeleteTask (TaskIdRequest) returns (MessageResponse);
   rpc GetAllTasksByUserId (UserIdRequest) returns (TaskListResponse);
+  
+  // New comment-related methods
+  rpc AddCommentToTask (AddCommentRequest) returns (CommentResponse);
+  rpc GetCommentsForTask (TaskCommentsRequest) returns (CommentListResponse);
+  rpc UpdateComment (UpdateCommentRequest) returns (CommentResponse);
 }
 
 message EmptyRequest {}
@@ -80,4 +85,34 @@ message TaskListResponse {
 
 message MessageResponse {
   string message = 1;
+}
+
+// New message types for comment functionality
+message AddCommentRequest {
+  int32 taskId = 1;
+  string content = 2;
+  UserInfo user = 3;
+}
+
+message TaskCommentsRequest {
+  int32 taskId = 1;
+  UserInfo user = 2;
+}
+
+message CommentResponse {
+  int32 id = 1;
+  string content = 2;
+  string createdAt = 3;
+  UserInfo user = 4;
+}
+
+message CommentListResponse {
+  repeated CommentResponse comments = 1;
+}
+
+message UpdateCommentRequest {
+  int32 taskId = 1;
+  int32 commentId = 2;
+  string content = 3;
+  UserInfo user = 4;
 }

--- a/task-service/src/proto/task.proto
+++ b/task-service/src/proto/task.proto
@@ -18,6 +18,7 @@ service TaskService {
   rpc AddCommentToTask (AddCommentRequest) returns (CommentResponse);
   rpc GetCommentsForTask (TaskCommentsRequest) returns (CommentListResponse);
   rpc UpdateComment (UpdateCommentRequest) returns (CommentResponse);
+  rpc DeleteComment (DeleteCommentRequest) returns (MessageResponse);
 }
 
 message EmptyRequest {}
@@ -115,4 +116,10 @@ message UpdateCommentRequest {
   int32 commentId = 2;
   string content = 3;
   UserInfo user = 4;
+}
+
+message DeleteCommentRequest{
+  int32 taskId = 1;
+  int32 commentId = 2;
+  UserInfo user = 3;
 }

--- a/task-service/src/task/dto/comment-response.dto.ts
+++ b/task-service/src/task/dto/comment-response.dto.ts
@@ -1,0 +1,35 @@
+// src/task/dto/comment-response.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserInfoDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ example: 'John Doe' })
+  name: string;
+
+  @ApiProperty({ example: 'user' })
+  role: string;
+}
+
+export class CommentResponseDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'This task is progressing well!' })
+  content: string;
+
+  @ApiProperty({ example: '2025-05-16T10:30:00Z' })
+  createdAt: string;
+
+  @ApiProperty()
+  user: UserInfoDto;
+}
+
+export class CommentListResponseDto {
+  @ApiProperty({ type: [CommentResponseDto] })
+  comments: CommentResponseDto[];
+}

--- a/task-service/src/task/dto/create-comment.dto.ts
+++ b/task-service/src/task/dto/create-comment.dto.ts
@@ -1,0 +1,15 @@
+// src/task/dto/create-comment.dto.ts
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateCommentDto {
+  @ApiProperty({
+    description: 'Content of the comment',
+    example: 'This task is progressing well!',
+    required: true
+  })
+  @IsNotEmpty()
+  @IsString()
+  @MinLength(1)
+  content: string;
+}

--- a/task-service/src/task/dto/update-comment.dto.ts
+++ b/task-service/src/task/dto/update-comment.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class UpdateCommentDto {
+  @ApiProperty({
+    description: 'Updated content of the comment',
+    example: 'This is the updated comment text'
+  })
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+}

--- a/task-service/src/task/dto/update-task.dto.ts
+++ b/task-service/src/task/dto/update-task.dto.ts
@@ -1,15 +1,15 @@
-import { IsNotEmpty, IsString, IsOptional, IsBoolean } from 'class-validator';
+import { IsOptional, IsString, IsBoolean } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateTaskDto {
     @ApiProperty({
         description: 'Title of the task',
         example: 'Updated project documentation',
-        required: true
+        required: false
     })
-    @IsNotEmpty()
     @IsString()
-    title: string;
+    @IsOptional()
+    title?: string;
 
     @ApiProperty({
         description: 'Detailed description of the task',

--- a/task-service/src/task/entities/comment.entity.ts
+++ b/task-service/src/task/entities/comment.entity.ts
@@ -1,0 +1,22 @@
+// src/task/entities/comment.entity.ts
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import { User } from './user.entity';
+import { Task } from './task.entity';
+
+@Entity('comments')
+export class Comment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  content: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => Task, (task) => task.comments, { onDelete: 'CASCADE' })
+  task: Task;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+}

--- a/task-service/src/task/entities/task.entity.ts
+++ b/task-service/src/task/entities/task.entity.ts
@@ -1,25 +1,30 @@
 // src/task/entities/task.entity.ts
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm'
-import { User } from './user.entity'
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from 'typeorm';
+import { User } from './user.entity';
+import { Comment } from './comment.entity';
 
 @Entity('tasks')
 export class Task {
   @PrimaryGeneratedColumn()
-  id: number
+  id: number;
 
   @Column()
-  title: string
+  title: string;
 
   @Column({ nullable: true })
-  description?: string
+  description?: string;
 
   @Column({ default: false })
-  isCompleted: boolean
+  isCompleted: boolean;
 
   @Column({ type: 'timestamp', nullable: true })
-  dueDate?: Date
+  dueDate?: Date;
 
   @ManyToOne(() => User, (user) => user.tasks, { onDelete: 'CASCADE' })
-  user: User
-  createdBy: any
+  user: User;
+  
+  @OneToMany(() => Comment, (comment) => comment.task)
+  comments: Comment[];
+  
+  createdBy: any;
 }

--- a/task-service/src/task/task.controller.ts
+++ b/task-service/src/task/task.controller.ts
@@ -12,28 +12,28 @@ interface TaskUser {
 
 @Controller()
 export class TaskController {
-  constructor(private readonly taskService: TaskService) {}
+  constructor(private readonly taskService: TaskService) { }
 
   @GrpcMethod('TaskService', 'CreateTask')
-  async createTask(data: { 
-    title: string; 
-    description?: string; 
-    isCompleted?: boolean; 
+  async createTask(data: {
+    title: string;
+    description?: string;
+    isCompleted?: boolean;
     dueDate?: string;
-    user: TaskUser 
+    user: TaskUser
   }) {
     try {
       if (!data.title) {
         throw new RpcException('Title is required');
       }
-      
+
       const createTaskDto: CreateTaskDto = {
         title: data.title,
         description: data.description,
         isCompleted: data.isCompleted,
         dueDate: data.dueDate
       };
-      
+
       return await this.taskService.create(createTaskDto, data.user);
     } catch (error) {
       throw new RpcException(error.message || 'Failed to create task');
@@ -46,7 +46,7 @@ export class TaskController {
       if (!data.user || !data.user.userId) {
         throw new RpcException('User information missing from request');
       }
-      
+
       const tasks = await this.taskService.findAll(data.user);
       return { tasks };
     } catch (error) {
@@ -55,19 +55,19 @@ export class TaskController {
   }
 
   @GrpcMethod('TaskService', 'GetTaskById')
-  async getTaskById(data: { 
-    id: number; 
+  async getTaskById(data: {
+    id: number;
     user: TaskUser
   }) {
     try {
       if (!data || typeof data.id !== 'number') {
         throw new RpcException('Invalid task ID format');
       }
-      
+
       if (!data.user || !data.user.userId) {
         throw new RpcException('User information missing from request');
       }
-      
+
       return await this.taskService.findOne(data.id, data.user);
     } catch (error) {
       throw new RpcException(error.message || 'Failed to retrieve task');
@@ -75,11 +75,11 @@ export class TaskController {
   }
 
   @GrpcMethod('TaskService', 'UpdateTask')
-  async updateTask(data: { 
-    id: number; 
-    title?: string; 
-    description?: string; 
-    isCompleted?: boolean; 
+  async updateTask(data: {
+    id: number;
+    title?: string;
+    description?: string;
+    isCompleted?: boolean;
     dueDate?: string;
     user: TaskUser
   }) {
@@ -87,11 +87,11 @@ export class TaskController {
       if (!data || typeof data.id !== 'number') {
         throw new RpcException('Invalid task data format');
       }
-      
+
       if (!data.user || !data.user.userId) {
         throw new RpcException('User information missing from request');
       }
-      
+
       const { id, user, ...updateData } = data;
       const updateTaskDto: UpdateTaskDto = {
         title: updateData.title,
@@ -99,7 +99,7 @@ export class TaskController {
         isCompleted: updateData.isCompleted,
         dueDate: updateData.dueDate
       };
-      
+
       return await this.taskService.update(id, updateTaskDto, user);
     } catch (error) {
       throw new RpcException(error.message || 'Failed to update task');
@@ -107,19 +107,19 @@ export class TaskController {
   }
 
   @GrpcMethod('TaskService', 'DeleteTask')
-  async deleteTask(data: { 
-    id: number; 
+  async deleteTask(data: {
+    id: number;
     user: TaskUser
   }) {
     try {
       if (!data || typeof data.id !== 'number') {
         throw new RpcException('Invalid task ID format');
       }
-      
+
       if (!data.user || !data.user.userId) {
         throw new RpcException('User information missing from request');
       }
-      
+
       await this.taskService.remove(data.id, data.user);
       return { message: 'Task deleted successfully' };
     } catch (error) {
@@ -143,7 +143,7 @@ export class TaskController {
       if (!data || typeof data.id !== 'number') {
         throw new RpcException('Invalid task ID format');
       }
-      
+
       return await this.taskService.getTaskByIdForAdmin(data.id);
     } catch (error) {
       throw new RpcException(error.message || 'Failed to retrieve task');
@@ -151,18 +151,18 @@ export class TaskController {
   }
 
   @GrpcMethod('TaskService', 'AdminUpdateTask')
-  async adminUpdateTask(data: { 
-    id: number; 
-    title?: string; 
-    description?: string; 
-    isCompleted?: boolean; 
-    dueDate?: string 
+  async adminUpdateTask(data: {
+    id: number;
+    title?: string;
+    description?: string;
+    isCompleted?: boolean;
+    dueDate?: string
   }) {
     try {
       if (!data || typeof data.id !== 'number') {
         throw new RpcException('Invalid task data format');
       }
-      
+
       const { id, ...updateData } = data;
       const updateTaskDto: UpdateTaskDto = {
         title: updateData.title,
@@ -170,7 +170,7 @@ export class TaskController {
         isCompleted: updateData.isCompleted,
         dueDate: updateData.dueDate
       };
-      
+
       return await this.taskService.adminUpdateTask(id, updateTaskDto);
     } catch (error) {
       throw new RpcException(error.message || 'Failed to update task');
@@ -183,7 +183,7 @@ export class TaskController {
       if (!data || typeof data.id !== 'number') {
         throw new RpcException('Invalid task ID format');
       }
-      
+
       await this.taskService.adminDeleteTask(data.id);
       return { message: 'Task deleted successfully' };
     } catch (error) {
@@ -197,7 +197,7 @@ export class TaskController {
       if (!data || typeof data.userId !== 'number') {
         throw new RpcException('Invalid user ID format');
       }
-      
+
       const tasks = await this.taskService.getAllTasksByUserId(data.userId);
       return { tasks };
     } catch (error) {
@@ -206,24 +206,24 @@ export class TaskController {
   }
 
   @GrpcMethod('TaskService', 'AddCommentToTask')
-  async addCommentToTask(data: { 
-    taskId: number; 
-    content: string; 
-    user: { userId: number; email: string; role: string } 
+  async addCommentToTask(data: {
+    taskId: number;
+    content: string;
+    user: { userId: number; email: string; role: string }
   }) {
     try {
       if (!data.taskId || typeof data.taskId !== 'number') {
         throw new RpcException('Invalid task ID format');
       }
-      
+
       if (!data.content) {
         throw new RpcException('Comment content is required');
       }
-      
+
       if (!data.user || !data.user.userId) {
         throw new RpcException('User information missing from request');
       }
-      
+
       return await this.taskService.addCommentToTask(data.taskId, data.content, data.user);
     } catch (error) {
       throw new RpcException(error.message || 'Failed to add comment');
@@ -231,19 +231,19 @@ export class TaskController {
   }
 
   @GrpcMethod('TaskService', 'GetCommentsForTask')
-  async getCommentsForTask(data: { 
-    taskId: number; 
-    user: { userId: number; email: string; role: string } 
+  async getCommentsForTask(data: {
+    taskId: number;
+    user: { userId: number; email: string; role: string }
   }) {
     try {
       if (!data.taskId || typeof data.taskId !== 'number') {
         throw new RpcException('Invalid task ID format');
       }
-      
+
       if (!data.user || !data.user.userId) {
         throw new RpcException('User information missing from request');
       }
-      
+
       const comments = await this.taskService.getCommentsForTask(data.taskId, data.user);
       return { comments };
     } catch (error) {
@@ -252,37 +252,55 @@ export class TaskController {
   }
 
   @GrpcMethod('TaskService', 'UpdateComment')
-  async updateComment(data: { 
-    taskId: number; 
+  async updateComment(data: {
+    taskId: number;
     commentId: number;
-    content: string; 
-    user: { userId: number; email: string; role: string } 
+    content: string;
+    user: { userId: number; email: string; role: string }
   }) {
     try {
       if (!data.taskId || typeof data.taskId !== 'number') {
         throw new RpcException('Invalid task ID format');
       }
-      
+
       if (!data.commentId || typeof data.commentId !== 'number') {
         throw new RpcException('Invalid comment ID format');
       }
-      
+
       if (!data.content) {
         throw new RpcException('Comment content is required');
       }
-      
+
       if (!data.user || !data.user.userId) {
         throw new RpcException('User information missing from request');
       }
-      
+
       return await this.taskService.updateComment(
-        data.taskId, 
-        data.commentId, 
-        { content: data.content }, 
+        data.taskId,
+        data.commentId,
+        { content: data.content },
         data.user
       );
     } catch (error) {
       throw new RpcException(error.message || 'Failed to update comment');
     }
   }
+
+  @GrpcMethod('TaskService', 'DeleteComment')
+  async deleteComment(data: { taskId: number; commentId: number; user: { userId: number } }) {
+    try {
+      if (!data || typeof data.taskId !== 'number') {
+        throw new RpcException('Invalid task ID format');
+      }
+
+      if (!data.user || !data.user.userId) {
+        throw new RpcException('User information missing from request');
+      }
+
+      return await this.taskService.deleteComment(data.taskId, data.commentId, data.user);
+    } catch (error) {
+      throw new RpcException(error.message || 'Failed to delete comment');
+    }
+  }
+
 }

--- a/task-service/src/task/task.module.ts
+++ b/task-service/src/task/task.module.ts
@@ -5,12 +5,14 @@ import { Task } from 'src/task/entities/task.entity';
 import { User } from 'src/task/entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule} from '@nestjs/config';
+import { Comment } from './entities/comment.entity';
 
 @Module({
   imports: [
     ConfigModule, 
     TypeOrmModule.forFeature([Task]),
     TypeOrmModule.forFeature([User]),
+    TypeOrmModule.forFeature([Comment]),
   ],
   controllers: [TaskController],
   providers: [TaskService],

--- a/task-service/src/task/task.service.ts
+++ b/task-service/src/task/task.service.ts
@@ -1,8 +1,18 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Task } from './entities/task.entity';
 import { User } from './entities/user.entity';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+import { Comment } from './entities/comment.entity';
+import { UpdateCommentDto } from './dto/update-comment.dto';
+
+interface TaskUser {
+  userId: number;
+  email?: string;
+  role?: string;
+}
 
 @Injectable()
 export class TaskService {
@@ -11,26 +21,27 @@ export class TaskService {
     private taskRepo: Repository<Task>,
     @InjectRepository(User)
     private userRepo: Repository<User>,
+    @InjectRepository(Comment)
+    private commentRepo: Repository<Comment>
   ) { }
 
-  async create(dto: any, user1: { userId: number; email?: string; role?: string }) {
-    const user = await this.userRepo.findOneBy({ id: user1.userId });
-    if (!user) {
+  async create(createTaskDto: CreateTaskDto, user: TaskUser) {
+    const userEntity = await this.userRepo.findOneBy({ id: user.userId });
+    if (!userEntity) {
       throw new NotFoundException('User not found');
     }
 
     const task = this.taskRepo.create({
-      title: dto.title,
-      description: dto.description,
-      isCompleted: dto.isCompleted || false,
-      dueDate: dto.dueDate,
-      user,
+      title: createTaskDto.title,
+      description: createTaskDto.description,
+      isCompleted: createTaskDto.isCompleted || false,
+      dueDate: createTaskDto.dueDate,
+      user: userEntity,
     });
     return await this.taskRepo.save(task);
   }
            
-
-  async findAll(user: { userId: number; email?: string; role?: string }) {
+  async findAll(user: TaskUser) {
     return await this.taskRepo.find({
       where: {
         user: { id: user.userId },
@@ -52,7 +63,7 @@ export class TaskService {
     });
   }
 
-  async findOne(id: number, user: { userId: number; email?: string; role?: string }) {
+  async findOne(id: number, user: TaskUser) {
     const task = await this.taskRepo.findOne({
       where: {
         id,
@@ -81,7 +92,7 @@ export class TaskService {
     return task;
   }
 
-  async update(id: number, updateTaskDto: any, user: { userId: number; email?: string; role?: string }) {
+  async update(id: number, updateTaskDto: UpdateTaskDto, user: TaskUser) {
     // First, find the task to ensure it exists and belongs to the user
     const task = await this.taskRepo.findOne({
       where: {
@@ -100,7 +111,7 @@ export class TaskService {
     return await this.taskRepo.save(task);
   }
 
-  async remove(id: number, user: { userId: number; email?: string; role?: string }) {
+  async remove(id: number, user: TaskUser) {
     // First, find the task to ensure it exists and belongs to the user
     const task = await this.taskRepo.findOne({
       where: {
@@ -164,7 +175,7 @@ export class TaskService {
     return task;
   }
 
-  async adminUpdateTask(id: number, updateTaskDto: any) {
+  async adminUpdateTask(id: number, updateTaskDto: UpdateTaskDto) {
     // First, find the task to ensure it exists
     const task = await this.taskRepo.findOne({
       where: { id },
@@ -219,5 +230,149 @@ export class TaskService {
     });
 
     return tasks;
+  }
+   async addCommentToTask(taskId: number, content: string, userInfo: { userId: number; email?: string; role?: string }) {
+    // Find the task
+    const task = await this.taskRepo.findOne({ 
+      where: { id: taskId },
+      relations: ['user']
+    });
+    
+    if (!task) {
+      throw new NotFoundException('Task not found');
+    }
+
+    // Check if the user has permission to comment on this task
+    // Users can comment on their own tasks or admins can comment on any task
+    if (task.user.id !== userInfo.userId && userInfo.role !== 'admin') {
+      throw new ForbiddenException('Permission denied to comment on this task');
+    }
+
+    // Find the user
+    const user = await this.userRepo.findOneBy({ id: userInfo.userId });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Create and save the comment
+    const comment = this.commentRepo.create({
+      content,
+      task,
+      user
+    });
+
+    const savedComment = await this.commentRepo.save(comment);
+    
+    // Format the response
+    return {
+      id: savedComment.id,
+      content: savedComment.content,
+      createdAt: savedComment.createdAt.toISOString(),
+      user: {
+        userId: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role
+      }
+    };
+  }
+
+  async getCommentsForTask(taskId: number, userInfo: { userId: number; email?: string; role?: string }) {
+    // Find the task
+    const task = await this.taskRepo.findOne({ 
+      where: { id: taskId },
+      relations: ['user']
+    });
+    
+    if (!task) {
+      throw new NotFoundException('Task not found');
+    }
+
+    // Check if the user has permission to view comments on this task
+    // Users can view comments on their own tasks or admins can view comments on any task
+    if (task.user.id !== userInfo.userId && userInfo.role !== 'admin') {
+      throw new ForbiddenException('Permission denied to view comments on this task');
+    }
+
+    // Find all comments for this task
+    const comments = await this.commentRepo.find({
+      where: { task: { id: taskId } },
+      relations: ['user'],
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        user: {
+          id: true,
+          email: true,
+          name: true,
+          role: true
+        }
+      },
+      order: {
+        createdAt: 'DESC'
+      }
+    });
+
+    // Format the response
+    return comments.map(comment => ({
+      id: comment.id,
+      content: comment.content,
+      createdAt: comment.createdAt.toISOString(),
+      user: {
+        userId: comment.user.id,
+        email: comment.user.email,
+        name: comment.user.name,
+        role: comment.user.role
+      }
+    }));
+  }
+  
+  async updateComment(taskId: number, commentId: number, updateCommentDto: UpdateCommentDto, userInfo: { userId: number; email?: string; role?: string }) {
+    // First, find the task to make sure it exists
+    const task = await this.taskRepo.findOne({ 
+      where: { id: taskId }
+    });
+    
+    if (!task) {
+      throw new NotFoundException('Task not found');
+    }
+
+    // Find the comment making sure it belongs to the specified task
+    const comment = await this.commentRepo.findOne({
+      where: { 
+        id: commentId,
+        task: { id: taskId }
+      },
+      relations: ['user']
+    });
+
+    if (!comment) {
+      throw new NotFoundException('Comment not found');
+    }
+
+    // Check if the user has permission to update this comment
+    // Only the comment author can update their own comment
+    if (comment.user.id !== userInfo.userId) {
+      throw new ForbiddenException('Permission denied to update this comment');
+    }
+
+    // Update the comment
+    comment.content = updateCommentDto.content;
+    
+    const updatedComment = await this.commentRepo.save(comment);
+    
+    // Format the response
+    return {
+      id: updatedComment.id,
+      content: updatedComment.content,
+      createdAt: updatedComment.createdAt.toISOString(),
+      user: {
+        userId: comment.user.id,
+        email: comment.user.email,
+        name: comment.user.name,
+        role: comment.user.role
+      }
+    };
   }
 }


### PR DESCRIPTION
### Description

This PR adds full CRUD functionality for comments associated with tasks. Authenticated users can now create, view, update, and delete comments on their own tasks.

---

### Features Implemented

- **POST /tasks/:taskId/comments**
  - Allow users to add a comment to a task
- **GET /tasks/:taskId/comments**
  - Retrieve all comments for a specific task
- **PATCH /tasks/:taskId/comments/:commentId**
  - Allow users to edit their own comments
- **DELETE /tasks/:taskId/comments/:commentId**
  - Allow users to delete their own comments

---

### Security & Validation

- Only authenticated users can perform comment actions
- Only the author of a comment can update or delete it
- Tasks and comments must belong to the requesting user

---

### Next Steps (Future PRs)

- Add admin routes:
  - View all comments
  - Delete any comment
  - View comments by task or user

---

### Screenshots / Testing Notes

 Manual testing done via Postman  
 Swagger updated with all new endpoints  
 gRPC methods added and working between api-gateway and task-service

---

### Checklist

- Comment entity already defined and used
- DTOs for create and update are validated
- Service and controller code separated clearly
- Authorization and error handling in place
