### PR TITLE
feat(ot-55): implement subtask creation, retrieval, update, and deletion for tasks

### DIFF
--- a/api-gateway/src/entities/subtask.entity.ts
+++ b/api-gateway/src/entities/subtask.entity.ts
@@ -1,0 +1,25 @@
+// api-gateway/src/entities/subtask.entity.ts
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import { User } from './user.entity';
+import { Task } from './task.entity';
+
+@Entity('subtasks')
+export class Subtask {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  content: string;
+
+  @Column({ default: false })
+  isCompleted: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => Task, (task) => task.subtasks, { onDelete: 'CASCADE' })
+  task: Task;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+}

--- a/api-gateway/src/entities/task.entity.ts
+++ b/api-gateway/src/entities/task.entity.ts
@@ -2,6 +2,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from 'typeorm';
 import { User } from './user.entity';
 import { Comment } from './comment.entity';
+import { Subtask } from './subtask.entity';
 
 @Entity('tasks')
 export class Task {
@@ -25,6 +26,9 @@ export class Task {
   
   @OneToMany(() => Comment, (comment) => comment.task)
   comments: Comment[];
+
+  @OneToMany(() => Subtask, (subtask) => subtask.task)
+  subtasks: Subtask[];
   
   createdBy: any;
 }

--- a/api-gateway/src/proto/task.proto
+++ b/api-gateway/src/proto/task.proto
@@ -19,6 +19,13 @@ service TaskService {
   rpc GetCommentsForTask (TaskCommentsRequest) returns (CommentListResponse);
   rpc UpdateComment (UpdateCommentRequest) returns (CommentResponse);
   rpc DeleteComment (DeleteCommentRequest) returns (MessageResponse);
+
+  
+  // New subtask methods
+  rpc AddSubtaskToTask (AddSubtaskRequest) returns (SubtaskResponse);
+  rpc GetSubtasksForTask (TaskSubtasksRequest) returns (SubtaskListResponse);
+  rpc UpdateSubtask (UpdateSubtaskRequest) returns (SubtaskResponse);
+  rpc DeleteSubtask (DeleteSubtaskRequest) returns (MessageResponse);
 }
 
 message EmptyRequest {}
@@ -121,5 +128,44 @@ message UpdateCommentRequest {
 message DeleteCommentRequest{
   int32 taskId = 1;
   int32 commentId = 2;
+  UserInfo user = 3;
+}
+
+// New message types for subtask functionality
+message AddSubtaskRequest {
+  int32 taskId = 1;
+  string content = 2;
+  bool isCompleted = 3;
+  UserInfo user = 4;
+}
+
+message TaskSubtasksRequest {
+  int32 taskId = 1;
+  UserInfo user = 2;
+}
+
+message SubtaskResponse {
+  int32 id = 1;
+  string content = 2;
+  bool isCompleted = 3;
+  string createdAt = 4;
+  UserInfo user = 5;
+}
+
+message SubtaskListResponse {
+  repeated SubtaskResponse subtasks = 1;
+}
+
+message UpdateSubtaskRequest {
+  int32 taskId = 1;
+  int32 subtaskId = 2;
+  string content = 3;
+  bool isCompleted = 4;
+  UserInfo user = 5;
+}
+
+message DeleteSubtaskRequest{
+  int32 taskId = 1;
+  int32 subtaskId = 2;
   UserInfo user = 3;
 }

--- a/api-gateway/src/task/dto/create-subtask.dto.ts
+++ b/api-gateway/src/task/dto/create-subtask.dto.ts
@@ -1,0 +1,20 @@
+// src/task/dto/create-Subtask.dto.ts
+import { IsBoolean, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateSubtaskDto {
+  @ApiProperty({
+    description: 'Content of the Subtask',
+    example: 'This task is progressing well!',
+    required: true
+  })
+  
+  @IsNotEmpty()
+  @IsString()
+  @MinLength(1)
+  content: string;
+
+  @IsNotEmpty()
+  @IsBoolean()
+  isCompleted: boolean;
+}

--- a/api-gateway/src/task/dto/subtask-response.dto.ts
+++ b/api-gateway/src/task/dto/subtask-response.dto.ts
@@ -1,0 +1,42 @@
+// src/task/dto/Subtask-response.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserInfoDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ example: 'John Doe' })
+  name: string;
+
+  @ApiProperty({ example: 'user' })
+  role: string;
+}
+
+export class SubtaskResponseDto {
+  @ApiProperty({ example: 1 })
+  taskId: number;
+
+  @ApiProperty({ example: 1 })
+  subtaskId: number;
+
+
+  @ApiProperty({ example: 'This task is progressing well!' })
+  content: string;
+
+  @ApiProperty({ example: true })
+  isCompleted: boolean;
+
+  @ApiProperty({ example: '2025-05-16T10:30:00Z' })
+  createdAt: string;
+
+  @ApiProperty()
+  user: UserInfoDto;
+}
+
+export class SubtaskListResponseDto {
+  @ApiProperty({ type: [SubtaskResponseDto] })
+  Subtasks: SubtaskResponseDto[];
+}

--- a/api-gateway/src/task/dto/update-subtask.dto.ts
+++ b/api-gateway/src/task/dto/update-subtask.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsBoolean } from 'class-validator';
+
+export class UpdateSubtaskDto {
+  @ApiProperty({
+    description: 'Updated content of the Subtask',
+    example: 'This is the updated Subtask text'
+  })
+
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  isCompleted:boolean;
+
+}

--- a/task-service/src/app.module.ts
+++ b/task-service/src/app.module.ts
@@ -8,6 +8,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { join } from 'path';
 import { Comment } from './task/entities/comment.entity';
+import { Subtask } from './task/entities/subtask.entity';
 
 @Module({
   imports: [
@@ -23,7 +24,7 @@ import { Comment } from './task/entities/comment.entity';
         username: config.get<string>('DB_USERNAME'),
         password: config.get<string>('DB_PASSWORD'),
         database: config.get<string>('DB_DATABASE'),
-        entities: [Task, User,Comment],
+        entities: [Task, User,Comment,Subtask],
         synchronize: true,
         logging: true,
       }),

--- a/task-service/src/proto/task.proto
+++ b/task-service/src/proto/task.proto
@@ -19,6 +19,13 @@ service TaskService {
   rpc GetCommentsForTask (TaskCommentsRequest) returns (CommentListResponse);
   rpc UpdateComment (UpdateCommentRequest) returns (CommentResponse);
   rpc DeleteComment (DeleteCommentRequest) returns (MessageResponse);
+
+  
+  // New subtask methods
+  rpc AddSubtaskToTask (AddSubtaskRequest) returns (SubtaskResponse);
+  rpc GetSubtasksForTask (TaskSubtasksRequest) returns (SubtaskListResponse);
+  rpc UpdateSubtask (UpdateSubtaskRequest) returns (SubtaskResponse);
+  rpc DeleteSubtask (DeleteSubtaskRequest) returns (MessageResponse);
 }
 
 message EmptyRequest {}
@@ -121,5 +128,44 @@ message UpdateCommentRequest {
 message DeleteCommentRequest{
   int32 taskId = 1;
   int32 commentId = 2;
+  UserInfo user = 3;
+}
+
+// New message types for subtask functionality
+message AddSubtaskRequest {
+  int32 taskId = 1;
+  string content = 2;
+  bool isCompleted = 3;
+  UserInfo user = 4;
+}
+
+message TaskSubtasksRequest {
+  int32 taskId = 1;
+  UserInfo user = 2;
+}
+
+message SubtaskResponse {
+  int32 id = 1;
+  string content = 2;
+  bool isCompleted = 3;
+  string createdAt = 4;
+  UserInfo user = 5;
+}
+
+message SubtaskListResponse {
+  repeated SubtaskResponse subtasks = 1;
+}
+
+message UpdateSubtaskRequest {
+  int32 taskId = 1;
+  int32 subtaskId = 2;
+  string content = 3;
+  bool isCompleted = 4;
+  UserInfo user = 5;
+}
+
+message DeleteSubtaskRequest{
+  int32 taskId = 1;
+  int32 subtaskId = 2;
   UserInfo user = 3;
 }

--- a/task-service/src/task/dto/update-subtask.dto.ts
+++ b/task-service/src/task/dto/update-subtask.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsBoolean } from 'class-validator';
+
+export class UpdateSubtaskDto {
+  @ApiProperty({
+    description: 'Updated content of the Subtask',
+    example: 'This is the updated Subtask text'
+  })
+
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  isCompleted:boolean;
+
+}

--- a/task-service/src/task/entities/subtask.entity.ts
+++ b/task-service/src/task/entities/subtask.entity.ts
@@ -1,0 +1,25 @@
+// src/task/entities/subtask.entity.ts
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import { User } from './user.entity';
+import { Task } from './task.entity';
+
+@Entity('subtasks')
+export class Subtask {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  content: string;
+
+  @Column({ default: false })
+  isCompleted: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => Task, (task) => task.subtasks, { onDelete: 'CASCADE' })
+  task: Task;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+}

--- a/task-service/src/task/entities/task.entity.ts
+++ b/task-service/src/task/entities/task.entity.ts
@@ -2,6 +2,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from 'typeorm';
 import { User } from './user.entity';
 import { Comment } from './comment.entity';
+import {Subtask} from './subtask.entity'
 
 @Entity('tasks')
 export class Task {
@@ -25,6 +26,9 @@ export class Task {
   
   @OneToMany(() => Comment, (comment) => comment.task)
   comments: Comment[];
+
+  @OneToMany(() => Subtask, (subtask) => subtask.task)
+  subtasks: Subtask[];
   
   createdBy: any;
 }

--- a/task-service/src/task/task.controller.ts
+++ b/task-service/src/task/task.controller.ts
@@ -303,4 +303,109 @@ export class TaskController {
     }
   }
 
+  
+  @GrpcMethod('TaskService', 'AddSubtaskToTask')
+  async addSubtaskToTask(data: {
+    taskId: number;
+    content: string;
+    isCompleted: boolean;
+    user: { userId: number; email: string; role: string }
+  }) {
+    try {
+      if (!data.taskId || typeof data.taskId !== 'number') {
+        throw new RpcException('Invalid task ID format');
+      }
+
+      if (!data.content) {
+        throw new RpcException('Subtask content is required');
+      }
+
+      if (!data.user || !data.user.userId) {
+        throw new RpcException('User information missing from request');
+      }
+
+      return await this.taskService.addSubtaskToTask(data.taskId, data.content,data.isCompleted, data.user);
+    } catch (error) {
+      throw new RpcException(error.message || 'Failed to add Subtask');
+    }
+  }
+
+  @GrpcMethod('TaskService', 'GetSubtasksForTask')
+  async getSubtasksForTask(data: {
+    taskId: number;
+    user: { userId: number; email: string; role: string }
+  }) {
+    try {
+      if (!data.taskId || typeof data.taskId !== 'number') {
+        throw new RpcException('Invalid task ID format');
+      }
+
+      if (!data.user || !data.user.userId) {
+        throw new RpcException('User information missing from request');
+      }
+
+      const subtasks = await this.taskService.getSubtasksForTask(data.taskId, data.user);
+      return { subtasks };
+    } catch (error) {
+      throw new RpcException(error.message || 'Failed to retrieve Subtask');
+    }
+  }
+
+  @GrpcMethod('TaskService', 'UpdateSubtask')
+  async updateSubtask(data: {
+    taskId: number;
+    subtaskId: number;
+    content: string;
+    isCompleted: boolean;
+    user: { userId: number; email: string; role: string }
+  }) {
+    try {
+      if (!data.taskId || typeof data.taskId !== 'number') {
+        throw new RpcException('Invalid task ID format');
+      }
+
+      if (!data.subtaskId || typeof data.subtaskId !== 'number') {
+        throw new RpcException('Invalid Subtask ID format');
+      }
+
+      if (!data.content) {
+        throw new RpcException('Subtask content is required');
+      }
+
+      if (!data.user || !data.user.userId) {
+        throw new RpcException('User information missing from request');
+      }
+
+      const something= await this.taskService.updateSubtask(
+        data.taskId,
+        data.subtaskId,
+        { content: data.content,
+          isCompleted: data.isCompleted
+        },
+        data.user
+      );
+      
+      return something;
+    } catch (error) {
+      throw new RpcException(error.message || 'Failed to update Subtask');
+    }
+  }
+
+  @GrpcMethod('TaskService', 'DeleteSubtask')
+  async deleteSubtask(data: { taskId: number; subtaskId: number; user: { userId: number } }) {
+    try {
+      if (!data || typeof data.taskId !== 'number') {
+        throw new RpcException('Invalid task ID format');
+      }
+
+      if (!data.user || !data.user.userId) {
+        throw new RpcException('User information missing from request');
+      }
+
+      return await this.taskService.deleteSubtask(data.taskId, data.subtaskId, data.user);
+    } catch (error) {
+      throw new RpcException(error.message || 'Failed to delete Subtask');
+    }
+  }
+
 }

--- a/task-service/src/task/task.module.ts
+++ b/task-service/src/task/task.module.ts
@@ -6,6 +6,7 @@ import { User } from 'src/task/entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule} from '@nestjs/config';
 import { Comment } from './entities/comment.entity';
+import { Subtask } from './entities/subtask.entity';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { Comment } from './entities/comment.entity';
     TypeOrmModule.forFeature([Task]),
     TypeOrmModule.forFeature([User]),
     TypeOrmModule.forFeature([Comment]),
+    TypeOrmModule.forFeature([Subtask]),
   ],
   controllers: [TaskController],
   providers: [TaskService],


### PR DESCRIPTION

### Description

This PR adds full CRUD functionality for subtasks associated with tasks. Authenticated users can now create, view, update, and delete comments on their tasks.

---

### Features Implemented


- Added POST /tasks/:id/subtasks to allow users to create subtasks
- Added GET /tasks/:id/subtasks to fetch all subtasks of a task
- Added PATCH /tasks/:taskId/subtasks/:subtaskId to update a specific subtask
- Added DELETE /tasks/:taskId/subtasks/:subtaskId to delete a specific subtask

---

### Security & Validation

- Only authenticated users can perform subtask actions
- Only the author of a subtask can update or delete it
- Tasks and subtasks must belong to the requesting user

---

### Next Steps (Future PRs)

- Add admin routes:
  - View all subtabs
  - Delete any subtasks
  - View subtasks by task or user

---

### Checklist

- Subtasks entity already defined and used
- DTOs for create and update are validated
- Service and controller code are separated clearly
- Authorization and error handling are in place
